### PR TITLE
fix: close plan gaps — lib/types.ts, constants meta fields, morning-r…

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -12,6 +12,18 @@ export const SCHEMA = {
   // Sorted sets and lists
   NEWSLETTER_IDS_KEY: "newsletter:ids",
 
+  // Meta hash field names (used when reading/writing newsletter:meta:{id})
+  META_FIELDS: {
+    TOPICS: "topics",
+    SUMMARY: "summary",
+    IS_READ: "isRead",
+    IS_ARCHIVED: "isArchived",
+    RECEIVED_AT: "receivedAt",
+    WORD_COUNT: "wordCount",
+    TAGS: "tags",
+    PREVIEW: "preview",
+  },
+
   // Hash fields
   METADATA_FIELDS: {
     ID: "id",

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -34,6 +34,10 @@ export interface Newsletter {
   // UI state
   isRead: boolean;        // Derived from metadata for easier access in components
   isArchived: boolean;    // Derived from metadata for easier access in components
+
+  // Topic classification and AI summary
+  topics?: string[];      // Categories assigned during ingestion (from data/topics.json)
+  summary?: string;       // AI-generated summary (stored at newsletter:summary:{id})
 }
 
 // BACKWARD COMPATIBILITY: Alias for existing dashboard

--- a/pages/api/morning-report.ts
+++ b/pages/api/morning-report.ts
@@ -16,7 +16,7 @@ interface TopicCategory {
   keywords?: string[];
 }
 
-interface DigestNewsletter {
+export interface DigestNewsletter {
   id: string;
   subject: string;
   sender: string;
@@ -28,13 +28,13 @@ interface DigestNewsletter {
   topics: string[];
 }
 
-interface CategoryGroup {
+export interface CategoryGroup {
   name: string;
   color: string;
   newsletters: DigestNewsletter[];
 }
 
-interface MorningReportResponse {
+export interface MorningReportData {
   date: string;
   categories: CategoryGroup[];
   uncategorized: DigestNewsletter[];
@@ -60,104 +60,104 @@ function isSameDay(dateStr: string, targetDate: Date): boolean {
   );
 }
 
+/**
+ * Core data-fetching logic — callable directly from getServerSideProps
+ * without making an HTTP round-trip.
+ */
+export async function getMorningReportData(dateParam?: string): Promise<MorningReportData> {
+  const targetDate = dateParam ? new Date(dateParam) : new Date();
+  const dateStr = targetDate.toISOString().split("T")[0];
+
+  // Load all IDs and filter to target date (O(n) scan, acceptable for daily digest)
+  const allIds = await redisClient.lrange(NEWSLETTER_IDS_KEY, 0, -1);
+
+  // Fetch metadata for all IDs in parallel, then filter by date
+  const metaResults = await Promise.all(
+    allIds.map(async (id) => {
+      try {
+        const meta = await redisClient.client.hgetall(`${META_PREFIX}${id}`);
+        return meta ? { id, meta } : null;
+      } catch {
+        return null;
+      }
+    })
+  );
+
+  const todayMeta = metaResults.filter(
+    (r): r is { id: string; meta: Record<string, string> } =>
+      r !== null && isSameDay(r.meta.receivedAt ?? r.meta.date ?? "", targetDate)
+  );
+
+  const categories = loadTopicCategories();
+  const categoryNames = categories.map((c) => c.name);
+
+  const digestItems: DigestNewsletter[] = await Promise.all(
+    todayMeta.map(async ({ id, meta }) => {
+      const summary = await getSummary(id).catch(() => null);
+      const topics: string[] = (() => {
+        try {
+          return JSON.parse(meta.topics ?? "[]");
+        } catch {
+          return ["Uncategorized"];
+        }
+      })();
+
+      return {
+        id,
+        subject: meta.subject ?? "(no subject)",
+        sender: meta.sender ?? "Unknown",
+        date: meta.receivedAt ?? meta.date ?? new Date().toISOString(),
+        summary,
+        preview: meta.preview ?? meta.previewText ?? "",
+        isRead: meta.isRead === "1",
+        isArchived: meta.isArchived === "1",
+        topics,
+      };
+    })
+  );
+
+  // Group by topic — each newsletter can appear in multiple categories
+  const grouped: Map<string, DigestNewsletter[]> = new Map();
+  const uncategorized: DigestNewsletter[] = [];
+
+  for (const item of digestItems) {
+    const itemTopics = item.topics.filter((t) => categoryNames.includes(t));
+    if (itemTopics.length === 0) {
+      uncategorized.push(item);
+    } else {
+      for (const topic of itemTopics) {
+        if (!grouped.has(topic)) grouped.set(topic, []);
+        grouped.get(topic)!.push(item);
+      }
+    }
+  }
+
+  const categoryGroups: CategoryGroup[] = categories
+    .filter((c) => grouped.has(c.name))
+    .map((c) => ({
+      name: c.name,
+      color: c.color,
+      newsletters: grouped.get(c.name)!,
+    }));
+
+  return { date: dateStr, categories: categoryGroups, uncategorized };
+}
+
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<MorningReportResponse | { error: string }>
+  res: NextApiResponse<MorningReportData | { error: string }>
 ) {
   if (req.method !== "GET") {
     return res.status(405).json({ error: "Method not allowed" });
   }
 
   try {
-    // Determine target date (defaults to today)
     const dateParam = req.query.date as string | undefined;
-    const targetDate = dateParam ? new Date(dateParam) : new Date();
-    if (isNaN(targetDate.getTime())) {
+    if (dateParam && isNaN(new Date(dateParam).getTime())) {
       return res.status(400).json({ error: "Invalid date parameter" });
     }
-    const dateStr = targetDate.toISOString().split("T")[0];
-
-    // Load all IDs and filter to target date (O(n) scan, acceptable for daily digest)
-    const allIds = await redisClient.lrange(NEWSLETTER_IDS_KEY, 0, -1);
-
-    // Fetch metadata for all IDs in parallel, then filter by date
-    const metaResults = await Promise.all(
-      allIds.map(async (id) => {
-        try {
-          const meta = await redisClient.client.hgetall(`${META_PREFIX}${id}`);
-          return meta ? { id, meta } : null;
-        } catch {
-          return null;
-        }
-      })
-    );
-
-    const todayMeta = metaResults.filter(
-      (r): r is { id: string; meta: Record<string, string> } =>
-        r !== null && isSameDay(r.meta.receivedAt ?? r.meta.date ?? "", targetDate)
-    );
-
-    // Fetch summaries and build digest items
-    const categories = loadTopicCategories();
-    const categoryNames = categories.map((c) => c.name);
-
-    const digestItems: DigestNewsletter[] = await Promise.all(
-      todayMeta.map(async ({ id, meta }) => {
-        const summary = await getSummary(id).catch(() => null);
-        const topics: string[] = (() => {
-          try {
-            return JSON.parse(meta.topics ?? "[]");
-          } catch {
-            return ["Uncategorized"];
-          }
-        })();
-
-        return {
-          id,
-          subject: meta.subject ?? "(no subject)",
-          sender: meta.sender ?? "Unknown",
-          date: meta.receivedAt ?? meta.date ?? new Date().toISOString(),
-          summary,
-          preview: meta.preview ?? meta.previewText ?? "",
-          isRead: meta.isRead === "1",
-          isArchived: meta.isArchived === "1",
-          topics,
-        };
-      })
-    );
-
-    // Group by topic — each newsletter can appear in multiple categories
-    const grouped: Map<string, DigestNewsletter[]> = new Map();
-    const uncategorized: DigestNewsletter[] = [];
-
-    for (const item of digestItems) {
-      const itemTopics = item.topics.filter((t) => categoryNames.includes(t));
-      if (itemTopics.length === 0) {
-        uncategorized.push(item);
-      } else {
-        for (const topic of itemTopics) {
-          if (!grouped.has(topic)) grouped.set(topic, []);
-          grouped.get(topic)!.push(item);
-        }
-      }
-    }
-
-    // Build response in topics.json order
-    const categoryGroups: CategoryGroup[] = categories
-      .filter((c) => grouped.has(c.name))
-      .map((c) => ({
-        name: c.name,
-        color: c.color,
-        newsletters: grouped.get(c.name)!,
-      }));
-
-    const response: MorningReportResponse = {
-      date: dateStr,
-      categories: categoryGroups,
-      uncategorized,
-    };
-
-    return res.status(200).json(response);
+    const data = await getMorningReportData(dateParam);
+    return res.status(200).json(data);
   } catch (error) {
     logger.error("Morning report error:", error);
     return res.status(500).json({ error: "Internal server error" });

--- a/pages/morning-report.tsx
+++ b/pages/morning-report.tsx
@@ -5,30 +5,9 @@ import { format } from "date-fns";
 import { useTheme } from "@/context/ThemeContext";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import FullViewArticle from "@/components/article/FullViewArticle";
+import type { DigestNewsletter, CategoryGroup, MorningReportData } from "@/pages/api/morning-report";
 
-interface DigestNewsletter {
-  id: string;
-  subject: string;
-  sender: string;
-  date: string;
-  summary: string | null;
-  preview: string;
-  isRead: boolean;
-  isArchived: boolean;
-  topics: string[];
-}
-
-interface CategoryGroup {
-  name: string;
-  color: string;
-  newsletters: DigestNewsletter[];
-}
-
-interface MorningReportProps {
-  date: string;
-  categories: CategoryGroup[];
-  uncategorized: DigestNewsletter[];
-}
+type MorningReportProps = MorningReportData;
 
 const COLOR_MAP: Record<string, string> = {
   blue:   "border-blue-400 bg-blue-50 dark:bg-blue-950 text-blue-800 dark:text-blue-200",
@@ -201,23 +180,16 @@ export default function MorningReport({ date, categories, uncategorized }: Morni
   );
 }
 
-export const getServerSideProps: GetServerSideProps = async (context) => {
+export const getServerSideProps: GetServerSideProps<MorningReportProps> = async (context) => {
   const { date } = context.query;
   const dateParam = typeof date === "string" ? date : new Date().toISOString().split("T")[0];
 
   try {
-    // Call the morning-report API internally
-    const baseUrl =
-      process.env.NEXT_PUBLIC_BASE_URL ??
-      `http://localhost:${process.env.PORT ?? 3000}`;
-
-    const res = await fetch(`${baseUrl}/api/morning-report?date=${dateParam}`);
-    if (!res.ok) throw new Error(`API responded with ${res.status}`);
-
-    const data = await res.json();
+    // Dynamic import keeps the Redis client out of the client-side bundle
+    const { getMorningReportData } = await import("@/pages/api/morning-report");
+    const data = await getMorningReportData(dateParam);
     return { props: data };
   } catch (error) {
-    // Return empty state on error rather than 500
     return {
       props: {
         date: dateParam,


### PR DESCRIPTION
…eport getServerSideProps

- lib/types.ts: add topics? and summary? to Newsletter (plan said to update this file; was mistakenly only added to types/newsletter.ts)
- lib/constants.ts: add META_FIELDS constants for topics, summary, isRead, etc. (plan called for meta field constants beyond just SUMMARY_PREFIX)
- pages/api/morning-report.ts: extract getMorningReportData() as a named export so getServerSideProps can call it directly without HTTP round-trip
- pages/morning-report.tsx: replace fetch(localhost) in getServerSideProps with dynamic import of getMorningReportData; use 'import type' for types to keep the Redis client out of the client-side bundle

https://claude.ai/code/session_01MW3haYf3zLL3rhLEg4wPCs