### PR TITLE
fix(classifier): match sender against full string, not just extracted…

### DIFF
--- a/pages/api/webhook.ts
+++ b/pages/api/webhook.ts
@@ -65,12 +65,20 @@ function classifyTopics(sender: string, subject: string, textSnippet: string): s
       fs.readFileSync(topicsPath, "utf-8")
     );
 
+    // Match against domain (after @) AND the full sender string so that
+    // topics.json entries can be display names, partial addresses, or domains
     const senderDomain = sender.match(/@([^>\s]+)/)?.[1]?.toLowerCase() ?? "";
+    const senderFull = sender.toLowerCase();
     const haystack = `${subject} ${textSnippet}`.toLowerCase();
 
     const matched = categories
       .filter((cat) => {
-        const senderMatch = cat.senders?.some((s) => senderDomain.includes(s.toLowerCase())) ?? false;
+        const senderMatch = cat.senders
+          ?.filter(Boolean)
+          .some((s) => {
+            const sl = s.toLowerCase();
+            return senderDomain.includes(sl) || senderFull.includes(sl);
+          }) ?? false;
         const keywordMatch = cat.keywords?.some((kw) => haystack.includes(kw.toLowerCase())) ?? false;
         return senderMatch || keywordMatch;
       })

--- a/scripts/backfill-topics.ts
+++ b/scripts/backfill-topics.ts
@@ -34,11 +34,17 @@ function classifyTopics(sender: string, subject: string, textSnippet: string): s
     );
 
     const senderDomain = sender.match(/@([^>\s]+)/)?.[1]?.toLowerCase() ?? "";
+    const senderFull = sender.toLowerCase();
     const haystack = `${subject} ${textSnippet}`.toLowerCase();
 
     const matched = categories
       .filter((cat) => {
-        const senderMatch = cat.senders?.some((s) => senderDomain.includes(s.toLowerCase())) ?? false;
+        const senderMatch = cat.senders
+          ?.filter(Boolean)
+          .some((s) => {
+            const sl = s.toLowerCase();
+            return senderDomain.includes(sl) || senderFull.includes(sl);
+          }) ?? false;
         const keywordMatch = cat.keywords?.some((kw) => haystack.includes(kw.toLowerCase())) ?? false;
         return senderMatch || keywordMatch;
       })


### PR DESCRIPTION
… domain

Topics.json entries like "pragmaticengineer" or "Jared Spool" were never matching because the classifier only checked the domain extracted after '@'. Now checks both the domain AND the full sender string, so display names, partial addresses, and substack slugs all work. Also filters out empty sender entries in topics.json.

Applied to both webhook.ts and scripts/backfill-topics.ts.

https://claude.ai/code/session_01MW3haYf3zLL3rhLEg4wPCs