### PR TITLE
fix(morning-report): use browser timezone cookie for local date bound…

### DIFF
--- a/pages/api/morning-report.ts
+++ b/pages/api/morning-report.ts
@@ -49,23 +49,27 @@ function loadTopicCategories(): TopicCategory[] {
   }
 }
 
-function isSameDay(dateStr: string, targetDate: Date): boolean {
+function isSameDay(dateStr: string, targetDateStr: string, timezone: string): boolean {
   const d = parseDate(dateStr, { fallbackBehavior: "null", logWarnings: false });
   if (!d) return false;
-  return (
-    d.getFullYear() === targetDate.getFullYear() &&
-    d.getMonth() === targetDate.getMonth() &&
-    d.getDate() === targetDate.getDate()
-  );
+  const localStr = new Intl.DateTimeFormat("en-CA", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(d);
+  return localStr === targetDateStr;
 }
 
 /**
  * Core data-fetching logic — callable directly from getServerSideProps
  * without making an HTTP round-trip.
  */
-export async function getMorningReportData(dateParam?: string, injectedCategories?: TopicCategory[]): Promise<MorningReportData> {
-  const targetDate = dateParam ? new Date(dateParam) : new Date();
-  const dateStr = targetDate.toISOString().split("T")[0];
+export async function getMorningReportData(dateParam?: string, injectedCategories?: TopicCategory[], timezone = "UTC"): Promise<MorningReportData> {
+  const tz = timezone || "UTC";
+  const dateStr = dateParam ?? new Intl.DateTimeFormat("en-CA", {
+    timeZone: tz, year: "numeric", month: "2-digit", day: "2-digit",
+  }).format(new Date());
 
   // Load all IDs and filter to target date (O(n) scan, acceptable for daily digest)
   const allIds = await redisClient.lrange(NEWSLETTER_IDS_KEY, 0, -1);
@@ -84,7 +88,7 @@ export async function getMorningReportData(dateParam?: string, injectedCategorie
 
   const todayMeta = metaResults.filter(
     (r): r is { id: string; meta: Record<string, string> } =>
-      r !== null && isSameDay(r.meta.receivedAt ?? r.meta.date ?? "", targetDate)
+      r !== null && isSameDay(r.meta.receivedAt ?? r.meta.date ?? "", dateStr, tz)
   );
 
   const categories = injectedCategories ?? loadTopicCategories();
@@ -154,10 +158,11 @@ export default async function handler(
 
   try {
     const dateParam = req.query.date as string | undefined;
+    const tz = req.query.tz as string | undefined;
     if (dateParam && isNaN(new Date(dateParam).getTime())) {
       return res.status(400).json({ error: "Invalid date parameter" });
     }
-    const data = await getMorningReportData(dateParam);
+    const data = await getMorningReportData(dateParam, undefined, tz);
     return res.status(200).json(data);
   } catch (error) {
     logger.error("Morning report error:", error);

--- a/pages/morning-report.tsx
+++ b/pages/morning-report.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { GetServerSideProps } from "next";
 import Link from "next/link";
 import { format } from "date-fns";
@@ -109,6 +109,13 @@ export default function MorningReport({ date, categories, uncategorized }: Morni
   const { theme } = useTheme();
   const [fullViewItem, setFullViewItem] = useState<DigestNewsletter | null>(null);
 
+  // Write the browser's IANA timezone to a cookie so getServerSideProps can
+  // compute "today" in the user's local timezone on subsequent requests.
+  useEffect(() => {
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    document.cookie = `tz=${encodeURIComponent(tz)}; path=/; max-age=31536000; SameSite=Lax`;
+  }, []);
+
   const totalCount = categories.reduce((s, c) => s + c.newsletters.length, 0) + uncategorized.length;
   const formattedDate = format(new Date(date + "T12:00:00"), "EEEE, MMMM d, yyyy");
 
@@ -184,7 +191,15 @@ export default function MorningReport({ date, categories, uncategorized }: Morni
 
 export const getServerSideProps: GetServerSideProps<MorningReportProps> = async (context) => {
   const { date } = context.query;
-  const dateParam = typeof date === "string" ? date : new Date().toISOString().split("T")[0];
+  const tz = context.req.cookies.tz
+    ? decodeURIComponent(context.req.cookies.tz)
+    : "UTC";
+  // Compute "today" in the user's local timezone. en-CA locale gives YYYY-MM-DD natively.
+  const localDate = new Intl.DateTimeFormat("en-CA", {
+    timeZone: tz, year: "numeric", month: "2-digit", day: "2-digit",
+  }).format(new Date());
+  // Explicit ?date= param wins over the cookie-derived local date
+  const dateParam = typeof date === "string" ? date : localDate;
 
   try {
     // Both imports are dynamic — server-side only, never bundled into the client
@@ -192,7 +207,7 @@ export const getServerSideProps: GetServerSideProps<MorningReportProps> = async 
       import("@/pages/api/morning-report"),
       import("@/data/topics.json"),
     ]);
-    const data = await getMorningReportData(dateParam, (topicsModule as any).default?.categories ?? (topicsModule as any).categories);
+    const data = await getMorningReportData(dateParam, (topicsModule as any).default?.categories ?? (topicsModule as any).categories, tz);
     return { props: data };
   } catch (error) {
     return {


### PR DESCRIPTION
…ary (issue #36)

- useEffect writes IANA tz to cookie on first render
- getServerSideProps reads cookie and computes local date via Intl.DateTimeFormat(en-CA)
- getMorningReportData gains timezone param; isSameDay now compares in user's timezone
- API handler accepts ?tz= query param for direct API calls
- First-time visitors fall back to UTC for one render, then cookie kicks in