### PR TITLE
fix: morning report detail view + Phase 2 content cleaner

### DIFF
--- a/lib/cleaners/contentCleaner.ts
+++ b/lib/cleaners/contentCleaner.ts
@@ -280,6 +280,22 @@ function extractEmailContent(html: string): string {
       }
     });
 
+    // 2b. Remove tracking pixels — <img> with 1×1 dimensions or max-height ≤ 12px
+    body.querySelectorAll("img").forEach((img) => {
+      const w = img.getAttribute("width");
+      const h = img.getAttribute("height");
+      const style = img.getAttribute("style") ?? "";
+      const maxH = /max-height\s*:\s*(\d+)px/i.exec(style);
+      if (
+        (w === "1" && h === "1") ||
+        w === "1" ||
+        h === "1" ||
+        (maxH && parseInt(maxH[1]) <= 12)
+      ) {
+        img.remove();
+      }
+    });
+
     // 3. Remove header chrome — containers where ALL links are nav labels
     //    e.g. the "Sign Up | Advertise | View Online" row at the top of TLDR.
     //    Process innermost elements first (reverse) so parent containers see
@@ -328,11 +344,67 @@ function extractEmailContent(html: string): string {
       });
     }
 
+    // 4b. Remove footer blocks — containers whose only content is unsubscribe/
+    //     copyright/address boilerplate. Walk up from the unsubscribe link to the
+    //     nearest div or td ancestor, and remove it if it contains no content
+    //     headings and no long paragraphs (i.e. it's pure footer chrome).
+    const UNSUB_SIGNALS = [
+      "unsubscribe",
+      "opt out",
+      "opt-out",
+      "manage preferences",
+      "manage subscriptions",
+      "email preferences",
+    ];
+    body.querySelectorAll("a").forEach((a) => {
+      if (!a.isConnected) return;
+      const text = (a.textContent ?? "").trim().toLowerCase();
+      if (!UNSUB_SIGNALS.some((s) => text.includes(s))) return;
+      let candidate: Element | null = a;
+      for (let i = 0; i < 6; i++) {
+        const parent: Element | null = candidate
+          ? candidate.parentElement
+          : null;
+        if (!parent || parent === body) break;
+        const tag = parent.tagName.toLowerCase();
+        if (tag === "div" || tag === "td") {
+          const hasHeadings = !!parent.querySelector("h1,h2,h3,h4");
+          const longParas = Array.from(parent.querySelectorAll("p")).filter(
+            (para) => (para.textContent ?? "").trim().length > 200,
+          );
+          if (!hasHeadings && longParas.length === 0) {
+            parent.remove();
+            return;
+          }
+        }
+        candidate = parent;
+      }
+    });
+
     // 5. Decode tracking URLs on all surviving links
     body.querySelectorAll("a[href]").forEach((a) => {
       const href = a.getAttribute("href") ?? "";
       const decoded = decodeTrackingUrl(href);
       if (decoded !== href) a.setAttribute("href", decoded);
+    });
+
+    // 4c. Unwrap constrained tracking anchors.
+    //     Gofobo-style ESPs wrap real text in <a style="max-width:19px;max-height:15px">
+    //     so the clickable area is invisible while text still renders. Unwrap these
+    //     anchors to remove the tracking link while preserving the visible content.
+    body.querySelectorAll("a[style]").forEach((a) => {
+      if (!a.isConnected) return;
+      const style = a.getAttribute("style") ?? "";
+      const maxW = /\bmax-width\s*:\s*(\d+)px/i.exec(style);
+      const maxH = /\bmax-height\s*:\s*(\d+)px/i.exec(style);
+      const isConstrained =
+        (maxW !== null && parseInt(maxW[1]) <= 20) ||
+        (maxH !== null && parseInt(maxH[1]) <= 20);
+      if (!isConstrained) return;
+      // Only unwrap if there's meaningful content inside
+      if ((a.textContent ?? "").trim().length < 3 && !a.querySelector("img"))
+        return;
+      a.replaceWith(...Array.from(a.childNodes));
     });
 
     // 6. Strip inline color/background properties so dark mode CSS can apply.

--- a/pages/morning-report.tsx
+++ b/pages/morning-report.tsx
@@ -5,26 +5,34 @@ import { format } from "date-fns";
 import { useTheme } from "@/context/ThemeContext";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import FullViewArticle from "@/components/article/FullViewArticle";
-import type { DigestNewsletter, CategoryGroup, MorningReportData } from "@/pages/api/morning-report";
+import type {
+  DigestNewsletter,
+  CategoryGroup,
+  MorningReportData,
+} from "@/pages/api/morning-report";
 
 type MorningReportProps = MorningReportData;
 
 const COLOR_MAP: Record<string, string> = {
-  blue:   "border-blue-400 bg-blue-50 dark:bg-blue-950 text-blue-800 dark:text-blue-200",
-  green:  "border-green-400 bg-green-50 dark:bg-green-950 text-green-800 dark:text-green-200",
-  orange: "border-orange-400 bg-orange-50 dark:bg-orange-950 text-orange-800 dark:text-orange-200",
-  yellow: "border-yellow-400 bg-yellow-50 dark:bg-yellow-950 text-yellow-800 dark:text-yellow-200",
-  purple: "border-purple-400 bg-purple-50 dark:bg-purple-950 text-purple-800 dark:text-purple-200",
-  gray:   "border-gray-400 bg-gray-50 dark:bg-gray-800 text-gray-800 dark:text-gray-200",
+  blue: "border-blue-400 bg-blue-50 dark:bg-blue-950 text-blue-800 dark:text-blue-200",
+  green:
+    "border-green-400 bg-green-50 dark:bg-green-950 text-green-800 dark:text-green-200",
+  orange:
+    "border-orange-400 bg-orange-50 dark:bg-orange-950 text-orange-800 dark:text-orange-200",
+  yellow:
+    "border-yellow-400 bg-yellow-50 dark:bg-yellow-950 text-yellow-800 dark:text-yellow-200",
+  purple:
+    "border-purple-400 bg-purple-50 dark:bg-purple-950 text-purple-800 dark:text-purple-200",
+  gray: "border-gray-400 bg-gray-50 dark:bg-gray-800 text-gray-800 dark:text-gray-200",
 };
 
 const DIVIDER_MAP: Record<string, string> = {
-  blue:   "border-blue-400",
-  green:  "border-green-400",
+  blue: "border-blue-400",
+  green: "border-green-400",
   orange: "border-orange-400",
   yellow: "border-yellow-400",
   purple: "border-purple-400",
-  gray:   "border-gray-400",
+  gray: "border-gray-400",
 };
 
 function NewsletterRow({
@@ -48,7 +56,9 @@ function NewsletterRow({
           </p>
           <h3
             className={`text-sm font-semibold leading-snug group-hover:text-blue-600 dark:group-hover:text-blue-400 ${
-              item.isRead ? "text-gray-500 dark:text-gray-400" : "text-gray-900 dark:text-white"
+              item.isRead
+                ? "text-gray-500 dark:text-gray-400"
+                : "text-gray-900 dark:text-white"
             }`}
           >
             {item.subject}
@@ -60,14 +70,21 @@ function NewsletterRow({
           )}
         </div>
         <div className="flex flex-col items-end gap-1 shrink-0">
-          <span className="text-xs text-gray-400 dark:text-gray-500 whitespace-nowrap" suppressHydrationWarning>
+          <span
+            className="text-xs text-gray-400 dark:text-gray-500 whitespace-nowrap"
+            suppressHydrationWarning
+          >
             {format(new Date(item.date), "h:mm a")}
           </span>
           {item.isRead && (
-            <span className="text-xs text-gray-400 dark:text-gray-500">read</span>
+            <span className="text-xs text-gray-400 dark:text-gray-500">
+              read
+            </span>
           )}
           {item.summary && (
-            <span className="text-xs text-emerald-600 dark:text-emerald-400">AI</span>
+            <span className="text-xs text-emerald-600 dark:text-emerald-400">
+              AI
+            </span>
           )}
         </div>
       </div>
@@ -89,11 +106,14 @@ function CategorySection({
   return (
     <section className={`mb-8 border-l-4 pl-4 ${dividerClass}`}>
       <div className="flex items-center gap-2 mb-3">
-        <span className={`text-xs font-semibold px-2 py-0.5 rounded-full border ${badgeClass}`}>
+        <span
+          className={`text-xs font-semibold px-2 py-0.5 rounded-full border ${badgeClass}`}
+        >
           {group.name}
         </span>
         <span className="text-xs text-gray-400 dark:text-gray-500">
-          {group.newsletters.length} {group.newsletters.length === 1 ? "newsletter" : "newsletters"}
+          {group.newsletters.length}{" "}
+          {group.newsletters.length === 1 ? "newsletter" : "newsletters"}
         </span>
       </div>
       <div>
@@ -105,9 +125,15 @@ function CategorySection({
   );
 }
 
-export default function MorningReport({ date, categories, uncategorized }: MorningReportProps) {
+export default function MorningReport({
+  date,
+  categories,
+  uncategorized,
+}: MorningReportProps) {
   const { theme } = useTheme();
-  const [fullViewItem, setFullViewItem] = useState<DigestNewsletter | null>(null);
+  const [fullViewItem, setFullViewItem] = useState<DigestNewsletter | null>(
+    null,
+  );
 
   // Write the browser's IANA timezone to a cookie so getServerSideProps can
   // compute "today" in the user's local timezone on subsequent requests.
@@ -116,8 +142,13 @@ export default function MorningReport({ date, categories, uncategorized }: Morni
     document.cookie = `tz=${encodeURIComponent(tz)}; path=/; max-age=31536000; SameSite=Lax`;
   }, []);
 
-  const totalCount = categories.reduce((s, c) => s + c.newsletters.length, 0) + uncategorized.length;
-  const formattedDate = format(new Date(date + "T12:00:00"), "EEEE, MMMM d, yyyy");
+  const totalCount =
+    categories.reduce((s, c) => s + c.newsletters.length, 0) +
+    uncategorized.length;
+  const formattedDate = format(
+    new Date(date + "T12:00:00"),
+    "EEEE, MMMM d, yyyy",
+  );
 
   const handleOpen = (item: DigestNewsletter) => setFullViewItem(item);
 
@@ -138,7 +169,9 @@ export default function MorningReport({ date, categories, uncategorized }: Morni
           <h1 className="text-3xl font-bold text-gray-900 dark:text-white mt-4">
             Morning Report
           </h1>
-          <p className="text-gray-500 dark:text-gray-400 mt-1">{formattedDate}</p>
+          <p className="text-gray-500 dark:text-gray-400 mt-1">
+            {formattedDate}
+          </p>
           <p className="text-sm text-gray-400 dark:text-gray-500 mt-1">
             {totalCount} newsletter{totalCount !== 1 ? "s" : ""} today
           </p>
@@ -147,17 +180,27 @@ export default function MorningReport({ date, categories, uncategorized }: Morni
         {totalCount === 0 ? (
           <div className="text-center py-16 text-gray-400 dark:text-gray-500">
             <p className="text-lg">No newsletters today.</p>
-            <p className="text-sm mt-2">Check back after your morning emails arrive.</p>
+            <p className="text-sm mt-2">
+              Check back after your morning emails arrive.
+            </p>
           </div>
         ) : (
           <>
             {categories.map((group) => (
-              <CategorySection key={group.name} group={group} onOpen={handleOpen} />
+              <CategorySection
+                key={group.name}
+                group={group}
+                onOpen={handleOpen}
+              />
             ))}
 
             {uncategorized.length > 0 && (
               <CategorySection
-                group={{ name: "Uncategorized", color: "gray", newsletters: uncategorized }}
+                group={{
+                  name: "Uncategorized",
+                  color: "gray",
+                  newsletters: uncategorized,
+                }}
                 onOpen={handleOpen}
               />
             )}
@@ -171,7 +214,7 @@ export default function MorningReport({ date, categories, uncategorized }: Morni
           article={{
             id: fullViewItem.id,
             title: fullViewItem.subject,
-            content: fullViewItem.summary ?? fullViewItem.preview ?? "",
+            content: "",
             publishDate: fullViewItem.date,
             sender: fullViewItem.sender,
             isRead: fullViewItem.isRead,
@@ -189,14 +232,19 @@ export default function MorningReport({ date, categories, uncategorized }: Morni
   );
 }
 
-export const getServerSideProps: GetServerSideProps<MorningReportProps> = async (context) => {
+export const getServerSideProps: GetServerSideProps<
+  MorningReportProps
+> = async (context) => {
   const { date } = context.query;
   const tz = context.req.cookies.tz
     ? decodeURIComponent(context.req.cookies.tz)
     : "UTC";
   // Compute "today" in the user's local timezone. en-CA locale gives YYYY-MM-DD natively.
   const localDate = new Intl.DateTimeFormat("en-CA", {
-    timeZone: tz, year: "numeric", month: "2-digit", day: "2-digit",
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
   }).format(new Date());
   // Explicit ?date= param wins over the cookie-derived local date
   const dateParam = typeof date === "string" ? date : localDate;
@@ -207,7 +255,12 @@ export const getServerSideProps: GetServerSideProps<MorningReportProps> = async 
       import("@/pages/api/morning-report"),
       import("@/data/topics.json"),
     ]);
-    const data = await getMorningReportData(dateParam, (topicsModule as any).default?.categories ?? (topicsModule as any).categories, tz);
+    const data = await getMorningReportData(
+      dateParam,
+      (topicsModule as any).default?.categories ??
+        (topicsModule as any).categories,
+      tz,
+    );
     return { props: data };
   } catch (error) {
     return {


### PR DESCRIPTION
## Summary

- **fix(morning-report):** Force `FullViewArticle` to fetch real content by newsletter ID rather than displaying the preview/summary text as the article body. Previously `content: preview` was passed, which exceeded the 30-char threshold that gates the fetch, so the modal showed garbled excerpt text instead of the full newsletter. Fix: pass `content: ""` so the fetch always fires. Closes #60.

- **feat(cleaner): Phase 2 content cleaning** — three new passes added to `extractEmailContent()` in `lib/cleaners/contentCleaner.ts`. Closes #61.
  - **Step 2b — Tracking pixel removal:** removes `<img>` elements with `width="1"` or `height="1"`, or `max-height ≤ 12px` in inline style (ESP preheader-style beacon images).
  - **Step 4b — Footer block removal:** walks up from any unsubscribe/opt-out/manage-preferences link to the nearest `div` or `td` ancestor; removes it if it contains no content headings (`h1`–`h4`) and no paragraphs longer than 200 chars (safe footer detection, won't nuke article content).
  - **Step 4c — Constrained anchor unwrapping:** Gofobo-style ESPs wrap visible text in `<a style="max-width:19px;max-height:15px">` to track clicks while keeping text renderable. Detects anchors with `max-width` or `max-height` ≤ 20px and unwraps them, preserving child nodes.

## Test plan

- [ ] Open a newsletter in the Morning Report → detail modal shows full content, not a truncated preview
- [ ] POST a Gofobo-style newsletter to `/api/webhook` → inspect stored `cleanContent` in Redis, confirm constrained `<a>` wrappers are unwrapped
- [ ] Confirm footer/unsubscribe block is absent from cleaned content
- [ ] Confirm 1×1 tracking pixels are stripped
- [ ] Run backfill on existing newsletters to apply Phase 2 passes retroactively
- [ ] Light mode and dark mode both render correctly after reprocessing

https://claude.ai/code/session_01MW3haYf3zLL3rhLEg4wPCs